### PR TITLE
fix peer dependency warning on React Native v60+

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
   "devDependencies": {},
   "peerDependencies": {
     "@types/react": "^16.8.23",
-    "@types/react-native": "^0.60.2",
+    "@types/react-native": "<=0.60.2",
     "prop-types": "^15.7.2",
     "react": "^16.8.3",
-    "react-native": "^0.59.0"
+    "react-native": "<=0.59.0"
   },
   "scripts": {}
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@types/react-native": "<=0.60.2",
     "prop-types": "^15.7.2",
     "react": "^16.8.3",
-    "react-native": "<=0.59.0"
+    "react-native": ">=0.59.0"
   },
   "scripts": {}
 }


### PR DESCRIPTION
should close #16 