### PR TITLE
Infinite loop from useEffect()

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ const ScalableImage = props => {
 
     useEffect(() => {
         onProps(props);
-    });
+    }, []);
 
     useEffect(() => {
         setImage(


### PR DESCRIPTION
Memory leak detected. Passing an empty array as the second argument to useEffect makes it only run on mount and unmount, thus stopping any infinite loops.