### PR TITLE
Do not create empty Image component

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ const ScalableImage = props => {
 
     const [scalableWidth, setScalableWidth] = useState(null);
     const [scalableHeight, setScalableHeight] = useState(null);
-    const [image, setImage] = useState(<ImageComponent />);
+    const [image, setImage] = useState(null);
     const mounted = useRef(false);
 
     useEffect(() => {


### PR DESCRIPTION
Creating an empty ImageBackground component with no props results in a `TypeError: Cannot read property 'width' of undefined when using ImageBackground` error immediately